### PR TITLE
fix: set max height to game image

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 detekt = "1.23.0"
-kotlin = "1.9.0-Beta"
+kotlin = "1.8.20"
 kotlinx-gettext = "0.5.2"
 retrofit = "2.9.0"
 sqldelight = "2.0.0-alpha05"

--- a/script/version-catalog-update.gradle
+++ b/script/version-catalog-update.gradle
@@ -1,3 +1,6 @@
 versionCatalogUpdate {
     sortByKey = true
+    pin {
+        versions = ["kotlin"]
+    }
 }

--- a/src/commonMain/kotlin/appoutlet/gameoutlet/feature/game/composable/GameDetailsImage.kt
+++ b/src/commonMain/kotlin/appoutlet/gameoutlet/feature/game/composable/GameDetailsImage.kt
@@ -3,6 +3,7 @@ package appoutlet.gameoutlet.feature.game.composable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -19,7 +20,7 @@ import io.kamel.image.lazyPainterResource
 
 @Composable
 fun GameDetailsImage(uiState: GameUiModel, modifier: Modifier = Modifier) {
-    Box(modifier = modifier.fillMaxWidth()) {
+    Box(modifier = modifier.fillMaxWidth().height(256.dp)) {
         KamelImage(
             modifier = Modifier
                 .matchParentSize()


### PR DESCRIPTION
### Why?
Large images can make the Game details screen hard to see

### How?
Set the maximum height to the game image

### How does it look?
<!--- If the change affects the UI, provide screenshots/gifs in this table of the before and after --->
| Before                       | After                       |
|------------------------------|-----------------------------|
| ![Screenshot 2023-05-30 at 19 13 08](https://github.com/AppOutlet/GameOutlet/assets/10220064/b0252506-18a7-42ea-aa5e-73d382f3ebde)| ![Screenshot 2023-05-30 at 19 12 15](https://github.com/AppOutlet/GameOutlet/assets/10220064/6d7fcdcb-d303-496e-b60b-2718668d809b)|


With :heart: 
