### PR TITLE
Enable settings screen

### DIFF
--- a/src/commonMain/kotlin/appoutlet/gameoutlet/feature/home/HomeView.kt
+++ b/src/commonMain/kotlin/appoutlet/gameoutlet/feature/home/HomeView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import appoutlet.gameoutlet.core.ui.spacing
 import appoutlet.gameoutlet.feature.home.composable.GameSearchTab
 import appoutlet.gameoutlet.feature.home.composable.LatestDealsTab
+import appoutlet.gameoutlet.feature.home.composable.SettingsTab
 import appoutlet.gameoutlet.feature.home.composable.StoresTab
 import appoutlet.gameoutlet.feature.home.composable.WishlistTab
 import cafe.adriel.voyager.core.screen.Screen
@@ -63,7 +64,7 @@ private fun HomeViewContent() {
                     modifier = Modifier.semantics { testTag = "storesTab" },
                     tab = StoresTab
                 )
-                // DrawerNavigationItem(modifier = Modifier.semantics { testTag = "settingsTab" }, tab = SettingsTab)
+                DrawerNavigationItem(modifier = Modifier.semantics { testTag = "settingsTab" }, tab = SettingsTab)
             }
         }) {
             Box(modifier = Modifier.fillMaxSize()) {

--- a/src/commonMain/kotlin/appoutlet/gameoutlet/feature/home/composable/SettingsTab.kt
+++ b/src/commonMain/kotlin/appoutlet/gameoutlet/feature/home/composable/SettingsTab.kt
@@ -1,5 +1,6 @@
 package appoutlet.gameoutlet.feature.home.composable
 
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.runtime.Composable
@@ -9,7 +10,9 @@ import appoutlet.gameoutlet.feature.settings.SettingsView
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import cafe.adriel.voyager.transitions.SlideTransition
 
+@OptIn(ExperimentalAnimationApi::class)
 object SettingsTab : Tab {
     override val options: TabOptions
         @Composable
@@ -21,6 +24,8 @@ object SettingsTab : Tab {
 
     @Composable
     override fun Content() {
-        Navigator(SettingsView())
+        Navigator(SettingsView()) {
+            SlideTransition(it)
+        }
     }
 }

--- a/src/commonMain/kotlin/appoutlet/gameoutlet/feature/settings/SettingsUiState.kt
+++ b/src/commonMain/kotlin/appoutlet/gameoutlet/feature/settings/SettingsUiState.kt
@@ -4,4 +4,5 @@ import appoutlet.gameoutlet.feature.common.UiState
 
 sealed interface SettingsUiState : UiState {
     object Idle : SettingsUiState
+    object Loading : SettingsUiState
 }

--- a/src/commonMain/kotlin/appoutlet/gameoutlet/feature/settings/SettingsView.kt
+++ b/src/commonMain/kotlin/appoutlet/gameoutlet/feature/settings/SettingsView.kt
@@ -1,13 +1,8 @@
 package appoutlet.gameoutlet.feature.settings
 
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
-import appoutlet.gameoutlet.core.translation.i18n
 import appoutlet.gameoutlet.feature.common.View
+import appoutlet.gameoutlet.feature.settings.composable.SettingsScreen
 import org.koin.core.component.inject
 
 class SettingsView : View<SettingsUiState, SettingsInputEvent>() {
@@ -15,10 +10,6 @@ class SettingsView : View<SettingsUiState, SettingsInputEvent>() {
 
     @Composable
     override fun ViewContent(uiState: SettingsUiState, onInputEvent: (SettingsInputEvent) -> Unit) {
-        Text(
-            modifier = Modifier.semantics { testTag = "screenTitle" },
-            text = i18n.tr("Settings"),
-            style = MaterialTheme.typography.headlineLarge
-        )
+        SettingsScreen(uiState, onInputEvent)
     }
 }

--- a/src/commonMain/kotlin/appoutlet/gameoutlet/feature/settings/composable/SettingsScreen.kt
+++ b/src/commonMain/kotlin/appoutlet/gameoutlet/feature/settings/composable/SettingsScreen.kt
@@ -1,0 +1,22 @@
+package appoutlet.gameoutlet.feature.settings.composable
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import appoutlet.gameoutlet.core.translation.i18n
+import appoutlet.gameoutlet.feature.common.composable.ScreenTitle
+import appoutlet.gameoutlet.feature.settings.SettingsInputEvent
+import appoutlet.gameoutlet.feature.settings.SettingsUiState
+
+@Suppress("UnusedParameter")
+@Composable
+fun SettingsScreen(
+    uiState: SettingsUiState,
+    onInputEvent: (SettingsInputEvent) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        ScreenTitle(i18n.tr("Settings"))
+    }
+}

--- a/src/commonTest/kotlin/appoutlet/gameoutlet/feature/home/HomeViewTest.kt
+++ b/src/commonTest/kotlin/appoutlet/gameoutlet/feature/home/HomeViewTest.kt
@@ -22,7 +22,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
 import org.koin.dsl.module
-import kotlin.test.Ignore
 
 class HomeViewTest : UiTest() {
     private val mockLatestDealsViewModel = mockk<LatestDealsViewModel>(relaxUnitFun = true) {
@@ -94,7 +93,6 @@ class HomeViewTest : UiTest() {
             .assertTextEquals(i18n.tr("Stores"))
     }
 
-    @Ignore("Removed temporarily")
     @Test
     fun `should navigate to Settings`() {
         composeTestRule.setContent { Navigator(HomeView()) }


### PR DESCRIPTION
### Why?
Create a place to the user change the application settings

### How?
Creating a settings screen

### How does it look?
![Screenshot 2023-06-06 at 20 25 05](https://github.com/AppOutlet/GameOutlet/assets/10220064/b78d2f94-9c36-4df3-ae32-3f9bd1336e5c)


### Checklist:
- [x] Unit tests created/updated
- [x] UI tests verified
- [x] Uploaded screenshots for design review

With :heart: 
